### PR TITLE
Fix tooltip and card adder types

### DIFF
--- a/vite-frontend/src/components/BulkCardAdder.tsx
+++ b/vite-frontend/src/components/BulkCardAdder.tsx
@@ -31,8 +31,7 @@ const BulkCardAdder: React.FC<BulkCardAdderProps> = ({ username, collectionId, o
 
   // Tooltip state
   const [tooltipOpen, setTooltipOpen] = useState(false)
-
-  const tooltipTimeout = useRef<NodeJS.Timeout | null>(null)
+  const tooltipTimeout = useRef<number | null>(null)
 
   React.useEffect(() => {
     return () => {
@@ -41,7 +40,6 @@ const BulkCardAdder: React.FC<BulkCardAdderProps> = ({ username, collectionId, o
       }
     }
   }, [])
-
   const handleTooltipToggle = () => {
     setTooltipOpen(true)
     if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current)

--- a/vite-frontend/src/components/BulkCardAdder.tsx
+++ b/vite-frontend/src/components/BulkCardAdder.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import {
   Box,
   Typography,
@@ -31,15 +31,15 @@ const BulkCardAdder: React.FC<BulkCardAdderProps> = ({ username, collectionId, o
 
   // Tooltip state
   const [tooltipOpen, setTooltipOpen] = useState(false)
-  const tooltipTimeout = useRef<number | null>(null)
+  const tooltipTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {
       if (tooltipTimeout.current) {
-        clearTimeout(tooltipTimeout.current)
+        clearTimeout(tooltipTimeout.current);
       }
-    }
-  }, [])
+    };
+  }, []);
   const handleTooltipToggle = () => {
     setTooltipOpen(true)
     if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current)
@@ -100,7 +100,12 @@ const BulkCardAdder: React.FC<BulkCardAdderProps> = ({ username, collectionId, o
                 disableHoverListener
                 disableTouchListener
               >
-                <IconButton size="small" sx={{ ml: 1 }} onClick={handleTooltipToggle}>
+                <IconButton
+                  aria-label="Help about bulk add format"
+                  size="small"
+                  sx={{ ml: 1 }}
+                  onClick={handleTooltipToggle}
+                >
                   <HelpOutlineIcon fontSize="small" />
                 </IconButton>
               </Tooltip>

--- a/vite-frontend/src/components/BulkCardAdder.tsx
+++ b/vite-frontend/src/components/BulkCardAdder.tsx
@@ -31,7 +31,8 @@ const BulkCardAdder: React.FC<BulkCardAdderProps> = ({ username, collectionId, o
 
   // Tooltip state
   const [tooltipOpen, setTooltipOpen] = useState(false)
-  const tooltipTimeout = useRef<number | null>(null)
+
+  const tooltipTimeout = useRef<NodeJS.Timeout | null>(null)
 
   React.useEffect(() => {
     return () => {
@@ -40,6 +41,7 @@ const BulkCardAdder: React.FC<BulkCardAdderProps> = ({ username, collectionId, o
       }
     }
   }, [])
+
   const handleTooltipToggle = () => {
     setTooltipOpen(true)
     if (tooltipTimeout.current) clearTimeout(tooltipTimeout.current)


### PR DESCRIPTION
This PR changes the tooltip timeout handling to fix type errors and improves accessibility for the bulk add help button in `BulkCardAdder.tsx`.

**Changes:**

* Uses `useEffect` instead of `React.useEffect` for clarity and consistency.
* Updates the `tooltipTimeout` ref to use `ReturnType<typeof setTimeout>` for correct cross-platform type inference.
* Ensures the tooltip timeout is properly cleared on component unmount.
* Adds `aria-label` to the help icon for screen reader accessibility.
* Improves formatting and spacing around `IconButton` for better readability.
