### PR TITLE
Rebuild FAISS index using all descriptors, not just new session data

### DIFF
--- a/inference-backend/descriptor_update/descriptor_update.py
+++ b/inference-backend/descriptor_update/descriptor_update.py
@@ -18,9 +18,6 @@ import threading
 
 from .workers.feature_worker import process_record
 
-# ---------------------------
-# CONFIGURATION
-# ---------------------------
 logger = logging.getLogger(__name__)
 load_dotenv('.env')
 
@@ -38,16 +35,12 @@ H5_FEATURES_FILE = os.path.join(STAGING_DIR, 'candidate_features.h5')
 FAISS_INDEX_FILE = os.path.join(STAGING_DIR, 'faiss_ivf.index')
 ID_MAP_FILE = os.path.join(STAGING_DIR, 'id_map.json')
 
-# ---------------------------
-# UTILITY FUNCTIONS
-# ---------------------------
-
 def load_card_records():
     conn = psycopg2.connect(
         dbname=DB_NAME, user=DB_USER, password=DB_PASSWORD,
         host=DB_HOST, port=DB_PORT
     )
-    query = """
+    query = '''
         SELECT id AS scryfall_id,
                COALESCE(image_uris->>'png', image_uris->>'large') AS image_url,
                0 AS face_index
@@ -58,61 +51,10 @@ def load_card_records():
         AND digital = false
         AND (promo IS NULL OR promo = false)
         AND image_uris IS NOT NULL
-    """
+    '''
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(query)
         return cur.fetchall()
-
-def extract_features(image):
-    sift = cv2.SIFT_create(nfeatures=250)
-    clahe = cv2.createCLAHE(2.0, (8, 8))
-    resized = cv2.resize(image, (256, 256))
-    lab = cv2.cvtColor(resized, cv2.COLOR_BGR2LAB)
-    L, A, B = cv2.split(lab)
-    L = clahe.apply(L)
-    lab = cv2.merge((L, A, B))
-    image = cv2.cvtColor(lab, cv2.COLOR_LAB2BGR)
-    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-    kp, des = sift.detectAndCompute(gray, None)
-    if des is not None:
-        des /= (des.sum(axis=1, keepdims=True) + 1e-7)
-        des = np.sqrt(des).astype(np.float32)
-    return kp, des
-
-from utils.sift_features import find_closest_card_ransac
-
-def run_inference_check():
-    url = "https://cards.scryfall.io/large/front/3/3/3394cefd-a3c6-4917-8f46-234e441ecfb6.jpg"
-    expected_ids = [
-        "3394cefd-a3c6-4917-8f46-234e441ecfb6",
-        "710160a6-43b4-4ba7-9dcd-93e01befc66f",
-        "5c575b9c-0a0b-4a24-98ad-efe604ca33a7",
-    ]
-
-    try:
-        resp = requests.get(url, timeout=10)
-        img = cv2.imdecode(np.frombuffer(resp.content, np.uint8), cv2.IMREAD_COLOR)
-        if img is None:
-            logger.error("❌ Failed to decode test image for sanity check.")
-            return False
-    except Exception as e:
-        logger.error(f"❌ Failed to fetch test image: {e}")
-        return False
-
-    best_candidate, _, _, _, _ = find_closest_card_ransac(
-        img,
-        k=3,
-        min_candidate_matches=1,
-        MIN_INLIER_THRESHOLD=8,
-        max_candidates=10
-    )
-
-    if best_candidate in expected_ids:
-        logger.info(f"✅ Inference sanity check PASSED: matched expected ID {best_candidate}")
-        return True
-    else:
-        logger.error(f"❌ Inference sanity check FAILED: expected one of {expected_ids}, got {best_candidate}")
-        return False
 
 def ensure_staging_files_present():
     for fname in ["candidate_features.h5", "faiss_ivf.index", "id_map.json"]:
@@ -141,12 +83,39 @@ def open_h5_file_safely(file_path, backup_path, mode='a'):
             logger.error(f"❌ No backup available for HDF5: {file_path}")
             raise RuntimeError("HDF5 file unrecoverable.")
 
-# ---------------------------
-# MAIN PIPELINE
-# ---------------------------
+def run_inference_check():
+    from utils.sift_features import find_closest_card_ransac
+    url = "https://cards.scryfall.io/large/front/3/3/3394cefd-a3c6-4917-8f46-234e441ecfb6.jpg"
+    expected_ids = [
+        "3394cefd-a3c6-4917-8f46-234e441ecfb6",
+        "710160a6-43b4-4ba7-9dcd-93e01befc66f",
+        "5c575b9c-0a0b-4a24-98ad-efe604ca33a7",
+    ]
+    try:
+        resp = requests.get(url, timeout=10)
+        img = cv2.imdecode(np.frombuffer(resp.content, np.uint8), cv2.IMREAD_COLOR)
+        if img is None:
+            logger.error("❌ Failed to decode test image for sanity check.")
+            return False
+    except Exception as e:
+        logger.error(f"❌ Failed to fetch test image: {e}")
+        return False
+    best_candidate, *_ = find_closest_card_ransac(
+        img,
+        k=3,
+        min_candidate_matches=1,
+        MIN_INLIER_THRESHOLD=8,
+        max_candidates=10
+    )
+    if best_candidate in expected_ids:
+        logger.info(f"✅ Inference sanity check PASSED: matched expected ID {best_candidate}")
+        return True
+    else:
+        logger.error(f"❌ Inference sanity check FAILED: expected one of {expected_ids}, got {best_candidate}")
+        return False
+
 def run_descriptor_update_pipeline():
     ensure_staging_files_present()
-
     card_records = load_card_records()
     logger.info(f"🔄 Loaded {len(card_records)} card records for descriptor update.")
 
@@ -157,61 +126,53 @@ def run_descriptor_update_pipeline():
     new_records = [r for r in card_records if r['scryfall_id'] not in processed_ids]
     logger.info(f"🆕 {len(new_records)} new records requiring descriptor extraction.")
 
-    descriptor_files = []
-    batch_descriptors = []
-    id_map = []
-    descriptor_count = 0
     MAX_WORKERS = 4
-    FAISS_BATCH_SIZE = 5000
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as executor, open_h5_file_safely(H5_FEATURES_FILE, hf_backup, mode='a') as hf:
+        for result in tqdm(executor.map(process_record, new_records), total=len(new_records)):
+            if not result:
+                continue
+            scryfall_id = result["scryfall_id"]
+            image_url = result["image_url"]
+            keypoints = result["keypoints"]
+            descriptors = np.array(result["descriptors"], dtype=np.float16)
+            card_grp = hf.create_group(scryfall_id) if scryfall_id not in hf else hf[scryfall_id]
+            feat_grp = card_grp.create_group(f"feature_{len(card_grp)}")
+            feat_grp.create_dataset("descriptors", data=descriptors, compression="gzip")
+            feat_grp.create_dataset("keypoints", data=[json.dumps(keypoints)],
+                                    dtype=h5py.string_dtype(encoding="utf-8"),
+                                    compression="gzip")
+            feat_grp.attrs["image_url"] = image_url
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        with open_h5_file_safely(H5_FEATURES_FILE, hf_backup, mode='a') as hf, ProcessPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            for result in tqdm(executor.map(process_record, new_records), total=len(new_records)):
-                if not result:
-                    continue
-                scryfall_id = result["scryfall_id"]
-                image_url = result["image_url"]
-                keypoints = result["keypoints"]
-                descriptors = np.array(result["descriptors"], dtype=np.float16)
+    # Rebuild the FAISS index using ALL descriptors from H5
+    all_descriptors = []
+    id_map = []
+    with h5py.File(H5_FEATURES_FILE, 'r') as hf:
+        for card_id in hf.keys():
+            card_grp = hf[card_id]
+            for feat_key in card_grp.keys():
+                feat_grp = card_grp[feat_key]
+                descriptors = feat_grp["descriptors"][:].astype(np.float32)
+                all_descriptors.append(descriptors)
+                id_map.extend([card_id] * descriptors.shape[0])
+    if not all_descriptors:
+        logger.error("❌ No descriptors found; skipping FAISS rebuild.")
+        return
+    all_descriptors = np.vstack(all_descriptors)
 
-                card_grp = hf.create_group(scryfall_id) if scryfall_id not in hf else hf[scryfall_id]
-                feat_grp = card_grp.create_group(f"feature_{len(card_grp)}")
-                feat_grp.create_dataset("descriptors", data=descriptors, compression="gzip")
-                feat_grp.create_dataset("keypoints", data=[json.dumps(keypoints)],
-                                        dtype=h5py.string_dtype(encoding="utf-8"),
-                                        compression="gzip")
-                feat_grp.attrs["image_url"] = image_url
+    dim = all_descriptors.shape[1]
+    quantizer = faiss.IndexFlatL2(dim)
+    index = faiss.IndexIVFPQ(quantizer, dim, 256, 8, 8)
+    if all_descriptors.shape[0] < 256:
+        logger.error(f"❌ Not enough descriptors ({all_descriptors.shape[0]}) to train with nlist=256. Skipping FAISS rebuild.")
+        return
 
-                batch_descriptors.extend(descriptors.astype(np.float32))
-                id_map.extend([scryfall_id] * len(descriptors))
-                descriptor_count += len(descriptors)
-
-                if descriptor_count >= FAISS_BATCH_SIZE:
-                    path = os.path.join(temp_dir, f"desc_{len(descriptor_files)}.npy")
-                    np.save(path, np.vstack(batch_descriptors))
-                    descriptor_files.append(path)
-                    batch_descriptors.clear()
-                    descriptor_count = 0
-                    gc.collect()
-
-            if batch_descriptors:
-                path = os.path.join(temp_dir, f"desc_{len(descriptor_files)}.npy")
-                np.save(path, np.vstack(batch_descriptors))
-                descriptor_files.append(path)
-
-        if descriptor_files:
-            mmap_refs = [np.load(f, mmap_mode='r') for f in descriptor_files]
-            new_descriptors = np.vstack(mmap_refs)
-            dim = new_descriptors.shape[1]
-            quantizer = faiss.IndexFlatL2(dim)
-            index = faiss.IndexIVFPQ(quantizer, dim, 100, 8, 8)
-            index.train(new_descriptors[:10000])
-            index.nprobe = 10
-            index.add(new_descriptors)
-            faiss.write_index(index, FAISS_INDEX_FILE)
-            with open(ID_MAP_FILE, 'w') as f:
-                json.dump(id_map, f)
-            logger.info(f"✅ FAISS index updated with {index.ntotal} descriptors.")
+    index.train(all_descriptors[:10000])
+    index.nprobe = 10
+    index.add(all_descriptors)
+    faiss.write_index(index, FAISS_INDEX_FILE)
+    with open(ID_MAP_FILE, 'w') as f:
+        json.dump(id_map, f)
+    logger.info(f"✅ FAISS index rebuilt with {index.ntotal} descriptors.")
 
     if run_inference_check():
         for fname in ["candidate_features.h5", "faiss_ivf.index", "id_map.json"]:
@@ -219,22 +180,16 @@ def run_descriptor_update_pipeline():
             dst = os.path.join(RUN_DIR, fname)
             shutil.copy2(src, dst)
             logger.info(f"✅ Promoted {src} → {dst}")
-
-        # Run HF upload in background to prevent blocking Flask
         def upload_hf_background():
             try:
                 from .upload_to_hf import upload_descriptor_bundle_to_hf
                 upload_descriptor_bundle_to_hf()
             except Exception as e:
                 logger.warning(f"⚠️ HF upload failed in background: {e}")
-
         threading.Thread(target=upload_hf_background, daemon=True).start()
         logger.info("🚀 Started background thread for Hugging Face upload.")
     else:
         logger.error("❌ Inference validation failed. Staging model discarded.")
 
-# ---------------------------
-# CLI ENTRYPOINT
-# ---------------------------
 if __name__ == "__main__":
     run_descriptor_update_pipeline()


### PR DESCRIPTION
## **Summary:**

Previously, the descriptor update pipeline rebuilt the FAISS IVF+PQ index using only *new descriptors* from the current update session. This caused failures when the number of new descriptors was less than `nlist` (e.g., 200 descriptors vs. 256 clusters), resulting in:

```
RuntimeError: 'nx >= k' failed: Number of training points (200) should be at least as large as number of clusters (256)
```

This PR fixes that by:
Collecting **all descriptors from `candidate_features.h5`** during the rebuild step.
Rebuilding the FAISS index **top-to-bottom on each pipeline run**, ensuring consistent, complete indexing.
Preventing pipeline failures when updates yield small descriptor batches.
Maintaining the same pipeline structure, validation flow, and HF upload steps.