### PR TITLE
Add hCaptcha verification to login process

### DIFF
--- a/inference-backend/routes/auth/handlers/password.py
+++ b/inference-backend/routes/auth/handlers/password.py
@@ -64,6 +64,10 @@ def login():
     if not email or not password or not hcaptcha_token:
         logger.warning("Missing required login fields")
         return jsonify({"message": "Missing required fields"}), 400
+    
+    if not verify_hcaptcha(hcaptcha_token, request.remote_addr):
+      logger.warning("hCaptcha verification failed during login")
+      return jsonify({"message": "Invalid captcha"}), 400
 
     conn = pg_pool.getconn()
     try:


### PR DESCRIPTION
## Enforce hCaptcha on login with post-button reveal

### Summary

* **Backend**: 
  * Enforces `verify_hcaptcha` during `/login`.

* **Frontend**:

  * Removes pre-check `/auth/captcha_status` complexity.
  * Uses **post-button-click reveal** for hCaptcha to reduce initial friction.
  * Shows **yellow `info` alert** (“Please complete the hCaptcha to continue.”) instead of red.
  * Automatically resubmits login after hCaptcha completion.

